### PR TITLE
A few suggested Firefox and Selenium related tweaks

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,7 +5,7 @@ import sys
 import time
 from foxpuppet import FoxPuppet
 import pytest
-from selenium.webdriver import Firefox, FirefoxProfile
+from selenium.webdriver import Firefox
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from helper_prefs import set_prefs # noqa
 from os_handler import OSHandler
@@ -102,38 +102,18 @@ def firefox_options(conf, firefox_options, pref_set):
 
 
 @pytest.fixture
-def selenium_setup(pref_set, channel, firefox_options):
-    """Setup custom prefs and restart.
+def selenium(pref_set, channel, firefox_options):
+    """Start Firefox with custom preferences & binary.
     1. create FirefoxBinary object (with custom path)
     2. add custom preferences to firefox_options
-    3. create Firefox object (with custom: binary and preferences)
+    3. create Firefox object (with custom binary and preferences)
+    4. start browser for test
     4. copy profile to local cache for later use
-    5. quit firefox
+    5. quit firefox when test completed
     """
-
     binary = firefox_binary(channel)
     driver = Firefox(firefox_binary=binary, firefox_options=firefox_options)
     profile_copy(driver, pref_set)
-    driver.quit()
-
-
-@pytest.fixture
-def selenium(pref_set, channel):
-    """Start Firefox with custom profile & binary.
-    1. create FirefoxBinary object (with custom path)
-    2. create FirefoxProfile object (with pre-existing profile
-       from selenium_setup)
-    3. create Firefox object (with custom: binary, profile objects)
-    4. start browser for test
-    5. quite firefox when test completed
-    """
-
-    path_prof = path_profile(pref_set)
-
-    binary = firefox_binary(channel)
-    profile = FirefoxProfile(path_prof)
-
-    driver = Firefox(firefox_binary=binary, firefox_profile=profile)
     yield driver
     driver.quit()
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 git+git://github.com/mozilla/FoxPuppet
 PyPOM==1.1.1
 pytest==3.1.3
-#pytest-selenium==1.11.0
+pytest-selenium==1.11.0
 pytest-variables==1.5.1
 pytest-xdist==1.15.0
 selenium==3.4.0

--- a/tests/test_filesize.py
+++ b/tests/test_filesize.py
@@ -10,7 +10,7 @@ from helper_prefs import (
 from conftest import path_profile, PATH_CACHE
 
 
-def test_safebrowsing_contains_expected_files(selenium_setup, selenium, conf, pref_set, channel): # noqa
+def test_safebrowsing_contains_expected_files(selenium, conf, pref_set, channel): # noqa
 #def test_safebrowsing_contains_expected_files(selenium, conf, pref_set, channel): # noqa
     """Hardcoded location of safebrowsing directory will need to be updated
     to reflect new FF profile file directory. Also, hardcoded profile type


### PR DESCRIPTION
I'm not 100% sure that this doesn't break anything, because the tests are currently failing for me even without these changes. These are just a few small tweaks that should improve the speed and complexity of the tests:

* Avoid using a `FirefoxProfile` to set preferences, as this passes an entire directory to GeckoDriver. Instead, we can specify just the preferences we want to set, which is much lighter. If we run tests remotely later, this also saves bandwidth.
* Avoid launching Firefox twice. We shouldn't need to restart Firefox, as the preferences should take immediate effect. I've left the part that copies the profile, but I suspect we could later remove that too. Note that if we want to run these tests against a remote Firefox, we might not be able to access the profile without enhancements to GeckoDriver.
* Avoid using a `FirefoxBinary` object. The recommended approach is to set the binary path as an option, which is taken care of by the `firefox_path` fixture from pytest-selenium.