### PR TITLE
feat: add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,4 +9,6 @@ __pycache__
 *.BAK
 .firefox
 ~archive
-build
+LICENSE
+README.md
+scripts

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,6 @@ __pycache__
 *.BAK
 .firefox
 ~archive
+build
+README*
 LICENSE
-README.md
-scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM selenium/standalone-firefox
+
+USER root
+
+ARG FIREFOX_DOWNLOAD_URL=https://download.mozilla.org/?product=firefox-nightly-latest-ssl&lang=en-US&os=linux64 
+
+RUN apt-get -qqy update && apt-get install -qqy \ 
+    git \
+    python \
+    python-dev \
+    python-pip \ 
+    build-essential \
+    && pip install --upgrade pip \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+RUN pip install --upgrade pip && pip install tox 
+
+RUN wget --no-verbose -O /tmp/firefox.tar.bz2 $FIREFOX_DOWNLOAD_URL \
+  && rm -rf /opt/firefox \
+  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+  && rm /tmp/firefox.tar.bz2 \
+  && mv /opt/firefox /opt/firefox-nightly \
+  && ln -fs /opt/firefox-nightly/firefox /usr/bin/firefox
+
+EXPOSE 5900
+EXPOSE 4444
+
+WORKDIR /tests
+COPY . /tests
+RUN pip install -r /tests/requirements/requirements.txt
+
+
+CMD TEST_ENV=${TEST_ENV} pytest --channel="nightly" --pref-set="base" tests/test_tracking_protection.py -s 

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,13 @@ deps = -rrequirements/requirements.txt
 #commands = pytest --channel="nightly" --pref-set="moztestpub" --driver=Firefox tests/test_filesize.py -s
 commands = pytest --channel="nightly" --pref-set="base" tests/test_tracking_protection.py -s
 
+[testenv:itisatrap]
+recreate = True
+setenv = TEST_ENV=stage
+passenv = DISPLAY
+deps = -rrequirements/requirements.txt
+commands = pytest --driver=Firefox tests/test_shield_display.py -s
+
 [testenv:shield-display]
 recreate = True
 passenv = DISPLAY


### PR DESCRIPTION
r? @rbillings 

Closes #38 

tests fail w/ ERROR but Docker build is executing tests:

```
$ docker run -e "TEST_ENV=stage" firefoxtesteng/shavar-e2e-tests
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.1.3, py-1.5.3, pluggy-0.4.0 -- /usr/bin/python
cachedir: .cache
sensitiveurl: .*
metadata: {'Python': '2.7.12', 'Driver': None, 'Capabilities': {}, 'Base URL': '', 'Platform': 'Linux-4.9.87-linuxkit-aufs-x86_64-with-Ubuntu-16.04-xenial', 'Plugins': {'variables': '1.5.1', 'selenium': '1.11.0', 'xdist': '1.15.0', 'mozlog': '3.7', 'html': '1.17.0', 'base-url': '1.4.1', 'metadata': '1.7.0'}, 'Packages': {'py': '1.5.3', 'pytest': '3.1.3', 'pluggy': '0.4.0'}}
rootdir: /tests, inifile: tox.ini
plugins: base-url-1.4.1, variables-1.5.1, html-1.17.0, selenium-1.11.0, xdist-1.15.0, metadata-1.7.0, mozlog-3.7
collecting ... collected 2 items

tests/test_tracking_protection.py::test_tracking_protection_off[base-nightly] ERROR
tests/test_tracking_protection.py::test_tracking_protection_on[base-nightly] ERROR
=========================== short test summary info ============================
ERROR tests/test_tracking_protection.py::test_tracking_protection_off[base-nightly]
ERROR tests/test_tracking_protection.py::test_tracking_protection_on[base-nightly]

==================================== ERRORS ====================================
_________ ERROR at setup of test_tracking_protection_off[base-nightly] _________

```